### PR TITLE
fix: support for binding an explicit variant id

### DIFF
--- a/packages/react/src/components/builder-component.component.tsx
+++ b/packages/react/src/components/builder-component.component.tsx
@@ -153,6 +153,13 @@ export interface BuilderComponentProps {
   /**
    * Content entry ID for this component to fetch client side
    */
+
+  /**
+   * Pass in an explicit variant ID to render.
+   * Used to support server side rendering of a chosen variant.
+   */
+  explicitVariantId?: string;
+
   entry?: string;
   /**
    * @package
@@ -1061,6 +1068,7 @@ export class BuilderComponent extends React.Component<
                           ? 'null-content-prop'
                           : 'no-content-prop')
                       }
+                      explicitVariantId={this.props.explicitVariantId}
                       builder={this.builder}
                       ref={ref => (this.contentRef = ref)}
                       // TODO: pass entry in

--- a/packages/react/src/components/builder-content.component.tsx
+++ b/packages/react/src/components/builder-content.component.tsx
@@ -29,6 +29,13 @@ export type BuilderContentProps<ContentType> = {
    * @see content
    */
   inline?: boolean;
+
+  /**
+   * Pass in an explicit variant ID to render.
+   * Used to support server side rendering of a chosen variant.
+   */
+  explicitVariantId?: string;
+
   /**
    * @package
    * @deprecated
@@ -314,7 +321,7 @@ export class BuilderContent<ContentType extends object = any> extends React.Comp
     const useData: any = this.data;
     const TagName = this.props.dataOnly ? NoWrap : 'div';
     return (
-      <VariantsProvider initialContent={useData}>
+      <VariantsProvider initialContent={useData} explicitVariantId={this.props.explicitVariantId}>
         {(variants, renderScript) => {
           return (
             <React.Fragment>

--- a/packages/react/src/components/variants-provider.component.tsx
+++ b/packages/react/src/components/variants-provider.component.tsx
@@ -98,10 +98,11 @@ const variantsScript = (variantsString: string, contentId: string) =>
 
 interface VariantsProviderProps {
   initialContent: BuilderContent;
+  explicitVariantId?: string;
   children: (variants: BuilderContent[], renderScript?: () => JSX.Element) => JSX.Element;
 }
 
-export const VariantsProvider = ({ initialContent, children }: VariantsProviderProps) => {
+export const VariantsProvider = ({ initialContent, explicitVariantId, children }: VariantsProviderProps) => {
   if (Builder.isBrowser && !builder.canTrack) {
     return children([initialContent]);
   }
@@ -117,6 +118,11 @@ export const VariantsProvider = ({ initialContent, children }: VariantsProviderP
   }));
 
   const allVariants = [...variants, initialContent];
+
+  if (explicitVariantId) {
+    return children([allVariants.find(item => item.id === explicitVariantId)!]);
+  }
+
   if (Builder.isServer) {
     const variantsJson = JSON.stringify(
       Object.keys(initialContent.variations || {}).map(item => ({


### PR DESCRIPTION
## Description

There are a couple issues doing SSR with A/B testing variants:

1. The inline script to choose the appropriate template does not include the nonce, so it fails CSP
2. The rendered set of templates on the server side fails matching the initial client side render (where a specific chosen variant is the first react client render)

_Screenshot_
If relevant, add a screenshot or two of the changes you made.
